### PR TITLE
install postgresql13 and postgresql13-server to get psql and pg_isready binaries respectively

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,8 +1,9 @@
 FROM registry.access.redhat.com/ubi8/ubi-minimal:8.3
 
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
+    && rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && microdnf update \
-    && microdnf install pgbouncer \
+    && microdnf install pgbouncer procps postgresql13 postgresql13-server \
     && rm -rf /etc/pgbouncer/{pgbouncer.ini,userlist.txt} \
     && touch /etc/pgbouncer/{pgbouncer.ini,userlist.txt} \
     && chmod 777 /etc/pgbouncer/{pgbouncer.ini,userlist.txt} \


### PR DESCRIPTION
Local demo here: https://asciinema.org/a/419825

I wish I didn't have to pull in  the _whole postgresql server_, but I didn't find any package that had only supporting binaries like `pg_isready`. I could have gone with a simpler `ps | grep` style of liveness probe, but postgresql docs indicate `pg_isready` is intended specifically to fill this need.

Note that the `pg_isready` command _only_ checks that `pgbouncer` _itself_ is up and ready for connections. It says nothing about the remote psql server that it's pooling/proxying. That's why I added the `select 1` query for my simulated readiness check; issuing even a simple `select` like that exercises a real connection through to the remote psql server.

The actual updated liveness and readiness probe commands will come in a future e2e-deploy PR.