### PR TITLE
Fix the build of postigrade - microdnf failing to install pgbouncer

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,6 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.5
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && microdnf update \
+    && microdnf --enablerepo=epel-modular module enable nodejs:13 \
     && microdnf install pgbouncer procps postgresql13 postgresql13-server nmap-ncat jq \
     && microdnf clean all \
     && rm -rf /etc/pgbouncer/{pgbouncer.ini,userlist.txt,rdsca.cert} \


### PR DESCRIPTION
Somehow the c-ares package depencency for pgbouncer were not being brought it as they were part of epel-modular.  Packages in epel-modular cannot be installed unless their module/streams are enabled.
c-ares is included in both nodejs:13 as nodejs:16-epel. We're enabling the nodejs:13 module for the epel-modular repo so that dependency can be installed.