### PR TITLE
replace catastrophically slow jq with a Python script

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -3,7 +3,7 @@ FROM registry.access.redhat.com/ubi8/ubi-minimal:8.6
 RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm \
     && rpm -ivh https://download.postgresql.org/pub/repos/yum/reporpms/EL-8-x86_64/pgdg-redhat-repo-latest.noarch.rpm \
     && microdnf update \
-    && microdnf install pgbouncer procps postgresql14 postgresql14-server nmap-ncat jq \
+    && microdnf install pgbouncer procps postgresql14 postgresql14-server nmap-ncat \
     && microdnf clean all \
     && pip3 install -U pip \
     && pip install flatten-dict==0.4.2 \

--- a/Dockerfile
+++ b/Dockerfile
@@ -5,11 +5,14 @@ RUN rpm -ivh https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.
     && microdnf update \
     && microdnf install pgbouncer procps postgresql14 postgresql14-server nmap-ncat jq \
     && microdnf clean all \
+    && pip3 install -U pip \
+    && pip install flatten-dict==0.4.2 \
     && rm -rf /etc/pgbouncer/{pgbouncer.ini,userlist.txt,rdsca.cert} \
     && touch /etc/pgbouncer/{pgbouncer.ini,userlist.txt,rdsca.cert} \
     && chmod 777 /etc/pgbouncer/{pgbouncer.ini,userlist.txt,rdsca.cert} \
     && chmod 777 /var/{run,log}/pgbouncer
 
+ADD json_to_env.py /json_to_env.py
 ADD entrypoint.sh /entrypoint.sh
 ADD clowder_init.sh /clowder_init.sh
 ADD probe-liveness.sh /probe-liveness.sh

--- a/clowder_init.sh
+++ b/clowder_init.sh
@@ -1,18 +1,26 @@
-#!/bin/sh
+#!/usr/bin/env bash
+
+env_file="/tmp/clowder_envs.sh"
 
 if [[ -z "${ACG_CONFIG}" ]]; then
   export PG_BOUNCER_LISTEN_PORT="5432"
-else
-  export DB_NAME="`cat $ACG_CONFIG | jq -r '.database.name // empty'`"
-  export DB_HOST="`cat $ACG_CONFIG | jq -r '.database.hostname // empty'`"
-  export DB_PORT="`cat $ACG_CONFIG | jq -r '.database.port // empty'`"
-  export DB_USER="`cat $ACG_CONFIG | jq -r '.database.username // empty'`"
-  export DB_PASSWORD="`cat $ACG_CONFIG | jq -r '.database.password // empty'`"
-  export DB_SSLMODE="`cat $ACG_CONFIG | jq -r '.database.sslMode // empty'`"
-  export DB_CAFILE="/etc/pgbouncer/rdsca.cert"
-  export PG_BOUNCER_LISTEN_PORT="`cat $ACG_CONFIG | jq -r '.webPort'`"
+elif [[ ! -f "${env_file}" ]]; then
+  python3 /json_to_env.py --prefix "CLOWDER_" "${ACG_CONFIG}" > "${env_file}"
+fi
 
-  db_cert="`cat $ACG_CONFIG | jq -r '.database.rdsCa // empty'`"
+if [[ -f "${env_file}" && -n "${ACG_CONFIG}" ]]; then
+  source "${env_file}"
+
+  export DB_NAME="${CLOWDER_DATABASE_NAME}"
+  export DB_HOST="${CLOWDER_DATABASE_HOSTNAME}"
+  export DB_PORT="${CLOWDER_DATABASE_PORT}"
+  export DB_USER="${CLOWDER_DATABASE_USERNAME}"
+  export DB_PASSWORD="${CLOWDER_DATABASE_PASSWORD}"
+  export DB_SSLMODE="${CLOWDER_DATABASE_SSLMODE}"
+  export DB_CAFILE="/etc/pgbouncer/rdsca.cert"
+  export PG_BOUNCER_LISTEN_PORT="${CLOWDER_WEBPORT}"
+
+  db_cert="${CLOWDER_DATABASE_RDSCA}"
   >${DB_CAFILE}
   if [[ -n "${db_cert}" ]]; then
     echo "${db_cert}" > ${DB_CAFILE}

--- a/json_to_env.py
+++ b/json_to_env.py
@@ -1,0 +1,36 @@
+#!/usr/bin/env python3
+"""
+Read JSON file and dump contents to source-able shell script.
+
+Useful for extracting Clowder's $ACG_CONFIG file (usually '/cdapp/cdappconfig.json').
+"""
+import argparse
+import json
+import sys
+
+from flatten_dict import flatten
+
+
+def main():
+    parser = argparse.ArgumentParser(
+        description=__doc__,
+        formatter_class=argparse.ArgumentDefaultsHelpFormatter
+    )
+    parser.add_argument("-p", "--prefix", type=str, help="optional prefix for each variable's name")
+    parser.add_argument("-e", "--export", action='store_true', help="export the env vars")
+    parser.add_argument("inputfile", nargs="?", type=argparse.FileType("r"), help="JSON file input, or '-' to read stdin")
+    args = parser.parse_args()
+
+    if not args.inputfile:
+        sys.exit("Please provide an input file, or use '-' to read stdin.")
+
+    json_data = json.load(args.inputfile)
+    flat_data = flatten(json_data, reducer='underscore', enumerate_types=(list,))
+
+    for key, value in flat_data.items():
+        value = value.replace("'", "'\"'\"'") if isinstance(value, str) else value
+        key = f"{args.prefix if args.prefix else ''}{key}"
+        print(f"{'export ' if args.export else ''}{key.upper()}='{value}'")
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
This is necessary because `jq` `1.6` is **very** slow (10x or worse by my measurements) compared to `jq` `1.5`. Its unexpected slowness is causing pod liveness and readiness probes to exceed timeouts, and that results in frequent pod restarting. Apparently the performance regression was addressed in `jq` master (https://github.com/stedolan/jq/issues/1826#issuecomment-464480110, https://github.com/stedolan/jq/pull/1834) *more than three years ago*, but there has been no release since then, and there appears to be no current release plan (https://github.com/stedolan/jq/issues/2305). The future of the `jq` project is unclear; so, we should find something else that works and that we can rely on in the future. 😕 

I'm proposing we stop using `jq` in our probes and instead use this small Python script to extract Clowder configs into the environment once, write a more quickly processed file, and reuse that file in subsequent calls.

## Performance comparison

I very roughly benchmarked the performance differences by locally running Docker with a `cdappconf.json` copied from an ephemeral environment deployment.

### current postigrade image using jq 1.6 (slow)
```
❯ docker run --privileged -v $(pwd)/cdapp:/cdapp -e ACG_CONFIG=/cdapp/cdappconfig.json -it --entrypoint sh quay.io/cloudservices/postigrade:ab29854

sh-4.4# jq --version
jq-1.6
sh-4.4# env | grep -c ^DB_
0
sh-4.4# time for i in {1..100}; do source /clowder_init.sh > /dev/null; done

real	0m25.530s
user	0m24.403s
sys	0m2.205s
sh-4.4# env | grep -c ^DB_
7
```

### old postigrade image using jq 1.5 (fast)
```
❯ docker run --privileged -v $(pwd)/cdapp:/cdapp -e ACG_CONFIG=/cdapp/cdappconfig.json -it --entrypoint sh quay.io/cloudservices/postigrade:bf02247

sh-4.4# jq --version
jq-1.5
sh-4.4# env | grep -c ^DB_
0
sh-4.4# time for i in {1..100}; do source /clowder_init.sh > /dev/null; done && echo

real	0m3.019s
user	0m2.258s
sys	0m1.745s
sh-4.4# env | grep -c ^DB_
7
```

### with Python script and new tmp file (very fast)
```
❯ docker build -q -t postigrade:latest .
sha256:7458367c439b30b402645ef52423b493ea1511c11eb5735e763c3a40d8217974
❯ docker run --privileged -v $(pwd)/cdapp:/cdapp -e ACG_CONFIG=/cdapp/cdappconfig.json -it --entrypoint sh postigrade:latest

sh-4.4# env | grep -c ^DB_
0
sh-4.4# rm -f /tmp/clowder_envs.sh
sh-4.4# time for i in {1..100}; do source /clowder_init.sh > /dev/null; done

real	0m0.150s
user	0m0.124s
sys	0m0.024s
sh-4.4# env | grep -c ^DB_
7
```

### with Python script, but destroy tmp file each time

```
❯ docker build -q -t postigrade:latest .
sha256:7458367c439b30b402645ef52423b493ea1511c11eb5735e763c3a40d8217974
❯ docker run --privileged -v $(pwd)/cdapp:/cdapp -e ACG_CONFIG=/cdapp/cdappconfig.json -it --entrypoint sh postigrade:latest

sh-4.4# env | grep -c ^DB_
0
sh-4.4# time for i in {1..100}; do rm -f /tmp/clowder_envs.sh; source /clowder_init.sh > /dev/null; done

real	0m8.556s
user	0m7.394s
sys	0m1.020s
sh-4.4# env | grep -c ^DB_
7
```

The *first* time `/clowder_init.sh` is called, the Python script runs and is still about 3x slower than our old approach using jq 1.5, but it's also about 3x faster than the current jq 1.6. *Subsequent* calls to `/clowder_init.sh` are *very* fast because they're just reading the file that the Python script wrote in the first iteration.

Average results over 100 iterations:
- current image with jq 1.6: **255 ms** per `/clowder_init.sh` call
- older image with jq 1.5: **30 ms** per `/clowder_init.sh` call
- proposed image in this PR: **2 ms** per `/clowder_init.sh` call

How do the probes perform in an actual ephemeral environment deployment?

```
sh-4.4$ time /probe-liveness.sh 
localhost:8000 - accepting connections

real    0m0.008s
user    0m0.004s
sys     0m0.006s
sh-4.4$ time /probe-readiness.sh 
 psql_is_ready 

real    0m0.012s
user    0m0.004s
sys     0m0.007s
```

See also our recent discussions in Slack:
- https://ansible.slack.com/archives/C8VGAPJNN/p1655929184616189?thread_ts=1655924376.591149&cid=C8VGAPJNN
- https://ansible.slack.com/archives/C8VGAPJNN/p1655995461647799
- https://coreos.slack.com/archives/C022YV4E0NA/p1655930541439289?thread_ts=1655476360.723759&cid=C022YV4E0NA