### PR TITLE
Revert "bump probe timings and thresholds to handle slow clusters tha…

### DIFF
--- a/deployment/clowdapp.yaml
+++ b/deployment/clowdapp.yaml
@@ -27,20 +27,20 @@ objects:
           exec:
             command:
               - /probe-liveness.sh
-          failureThreshold: 4
-          initialDelaySeconds: 15
-          periodSeconds: 15
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 10
+          timeoutSeconds: 1
         readinessProbe:
           exec:
             command:
               - /probe-readiness.sh
-          failureThreshold: 4
-          initialDelaySeconds: 15
-          periodSeconds: 15
+          failureThreshold: 3
+          initialDelaySeconds: 5
+          periodSeconds: 10
           successThreshold: 1
-          timeoutSeconds: 10
+          timeoutSeconds: 1
         resources:
           requests:
             cpu: ${POSTIGRADE_LIMITS_CONTAINER_CPU_REQUEST}


### PR DESCRIPTION
…t may be failing and restarting pods too quickly"

This reverts commit ab298541afcded0c7a91ad23eb93b0effb940726.

----

The relaxed probe settings should no longer be necessary since https://github.com/cloudigrade/postigrade/pull/25 fixed our slow probes.